### PR TITLE
Auto refresh JD

### DIFF
--- a/BeatmapInfo.cs
+++ b/BeatmapInfo.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JDFixer
+{
+    public delegate void BeatmapInfoEventHandler(BeatmapInfo e);
+    public class BeatmapInfo
+    {
+        public static event BeatmapInfoEventHandler SelectedChanged;
+
+        public static void SetSelected(IDifficultyBeatmap diff)
+        {
+            var updatedMapInfo = diff == null ? Empty : new BeatmapInfo(diff);
+            Selected = updatedMapInfo;
+
+            SelectedChanged?.Invoke(updatedMapInfo);
+        }
+
+        public static BeatmapInfo Selected { get; private set; } = Empty;
+
+        public static BeatmapInfo Empty { get; } = new BeatmapInfo();
+
+        private BeatmapInfo()
+        {
+
+        }
+        public BeatmapInfo(IDifficultyBeatmap diff)
+        {
+
+            float bpm = diff.level.beatsPerMinute;
+            float njs = diff.noteJumpMovementSpeed;
+            float offset = diff.noteJumpStartBeatOffset;
+
+
+            JumpDistance = BeatmapUtils.CalculateJumpDistance(bpm, njs, offset);
+            MinJumpDistance = BeatmapUtils.CalculateJumpDistance(bpm, njs, -50f);
+        }
+
+        public float JumpDistance { get; }
+        public float MinJumpDistance { get; }
+
+
+    }
+}

--- a/BeatmapUtils.cs
+++ b/BeatmapUtils.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JDFixer
+{
+    static class BeatmapUtils
+    {
+        public static float CalculateJumpDistance(float bpm, float njs, float offset)
+        {
+            float jumpdistance = 0f; // In case
+            float halfjump = 4f;
+            float num = 60f / bpm;
+
+            while (njs * num * halfjump > 18)
+                halfjump /= 2;
+
+            halfjump += offset;
+            if (halfjump < 1) halfjump = 1f;
+
+            jumpdistance = njs * num * halfjump * 2;
+
+            return jumpdistance;
+        }
+    }
+}

--- a/Config.cs
+++ b/Config.cs
@@ -37,8 +37,8 @@ namespace JDFixer
         //public float selected_mapBPM = 1f;
         //public float selected_mapNJS = 1f;
         //public float selected_mapOffset = 1f;
-        public float selected_mapJumpDistance = 1f;
-        public float selected_mapLowest = 1f;
+        //public float selected_mapJumpDistance = 1f;
+        //public float selected_mapLowest = 1f;
 
 
         public JDFixerConfig()
@@ -48,7 +48,7 @@ namespace JDFixer
         [JsonConstructor]
         //public JDFixerConfig(bool enabled, bool enabledInPractice, float jumpDistance, int minJumpDistance, int maxJumpDistance, bool usePreferredJumpDistanceValues, List<NjsPref> preferredValues,float upper_threshold, float lower_threshold, float selected_mapBPM, float selected_mapNJS, float selected_mapOffset, float selected_mapJumpDistance)
         public JDFixerConfig(bool enabled, bool enabledInPractice, float jumpDistance, int minJumpDistance, int maxJumpDistance, bool usePreferredJumpDistanceValues, List<JDPref> preferredValues, 
-            float upper_threshold, float lower_threshold, bool use_heuristic, float selected_mapJumpDistance, float selected_mapLowest)
+            float upper_threshold, float lower_threshold, bool use_heuristic)
         {
             this.enabled = enabled;
             this.enabledInPractice = enabledInPractice;
@@ -66,8 +66,8 @@ namespace JDFixer
             //this.selected_mapBPM = selected_mapBPM;
             //this.selected_mapNJS = selected_mapNJS;
             //this.selected_mapOffset = selected_mapOffset;
-            this.selected_mapJumpDistance = selected_mapJumpDistance;
-            this.selected_mapLowest = selected_mapLowest;
+            //this.selected_mapJumpDistance = selected_mapJumpDistance;
+            //this.selected_mapLowest = selected_mapLowest;
     }
     }
 
@@ -101,8 +101,8 @@ namespace JDFixer
                     //UserConfig.selected_mapBPM = oldConfig.GetFloat("JDFixer", "selected_mapBPM", 1f, true);
                     //UserConfig.selected_mapNJS = oldConfig.GetFloat("JDFixer", "selected_mapNJS", 1f, true);
                     //UserConfig.selected_mapNJS = oldConfig.GetFloat("JDFixer", "selected_mapOffset", 1f, true);
-                    UserConfig.selected_mapJumpDistance = oldConfig.GetFloat("JDFixer", "selected_mapJumpDistance", 1f, true);
-                    UserConfig.selected_mapLowest = oldConfig.GetFloat("JDFixer", "selected_mapLowest", 1f, true);
+                    //UserConfig.selected_mapJumpDistance = oldConfig.GetFloat("JDFixer", "selected_mapJumpDistance", 1f, true);
+                    //UserConfig.selected_mapLowest = oldConfig.GetFloat("JDFixer", "selected_mapLowest", 1f, true);
 
                     try
                     {

--- a/HarmonyPatches.cs
+++ b/HarmonyPatches.cs
@@ -43,7 +43,7 @@ namespace JDFixer
                 // Heuristic: If map's original JD is less than the matching preference entry, play map at original JD
                 // Rationale: I created this mod because I don't like floaty maps. If the original JD chosen by the
                 // mapper is lower than my pick, it's probably more optimal than my pick.
-                if (Config.UserConfig.selected_mapJumpDistance <= desiredJumpDis && Config.UserConfig.use_heuristic)
+                if (BeatmapInfo.Selected.JumpDistance <= desiredJumpDis && Config.UserConfig.use_heuristic)
                 {
                     //Logger.log.Debug("Not Fixing: Original JD below or equal setpoint");
                     //Logger.log.Debug($"BPM/NJS/Offset {startBpm}/{startNoteJumpMovementSpeed}/{noteJumpStartBeatOffset}");

--- a/JDFixer.csproj
+++ b/JDFixer.csproj
@@ -132,6 +132,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BeatmapUtils.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="HarmonyPatches.cs" />
     <Compile Include="Logger.cs" />
@@ -144,6 +145,7 @@
     </Compile>
     <Compile Include="ReflectionUtil.cs" />
     <Compile Include="SliderButton.cs" />
+    <Compile Include="BeatmapInfo.cs" />
     <Compile Include="UI\ModifierUI.cs" />
     <Compile Include="UI\PreferencesFlowCoordinator.cs" />
     <Compile Include="UI\PreferencesListViewController.cs" />

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using IPA;
+using System;
 using System.Linq;
 using UnityEngine;
 
@@ -35,23 +36,6 @@ namespace JDFixer
             Logger.log = logger;
         }
 
-        public static float Calculate_JD(float bpm, float njs, float offset)
-        {
-            float jumpdistance = 0f; // In case
-            float halfjump = 4f;
-            float num = 60f / bpm;
-
-            while (njs * num * halfjump > 18)
-                halfjump /= 2;
-
-            halfjump += offset;
-            if (halfjump < 1) halfjump = 1f;
-
-            jumpdistance = njs * num * halfjump * 2;
-
-            return jumpdistance;
-        }
-
         // For when user selects a map with only 1 difficulty or selects a map but does not click a difficulty
         private void BSEvents_lateMenuSceneLoadedFresh(ScenesTransitionSetupDataSO obj)
         {
@@ -59,26 +43,25 @@ namespace JDFixer
 
             if (leveldetail != null)
             {
-                leveldetail.didChangeContentEvent += UI.ModifierUI.Leveldetail_didChangeContentEvent;
+                leveldetail.didChangeContentEvent += Leveldetail_didChangeContentEvent;
             }
         }
 
         // For when user explicitly clicks on a difficulty (Doesn't work if map has only 1 diff)
         private void BSEvents_difficultySelected(StandardLevelDetailViewController arg1, IDifficultyBeatmap level)
         {
-            float bpm = arg1.beatmapLevel.beatsPerMinute;
-            //float halfjump = 4f;
-            float njs = level.noteJumpMovementSpeed;
-            float offset = level.noteJumpStartBeatOffset;
-            
-            float map_jumpdistance = Calculate_JD(bpm, njs, offset);
-            float min_map_jumpdistance = Calculate_JD(bpm, njs, -50f);
+            BeatmapInfo.SetSelected(level);
+        }
 
-            Logger.log.Debug($"Difficulty Selected. BPM: {bpm} | NJS: {njs} | Offset: {offset} | Jump Distance: {map_jumpdistance} | Minimum: {min_map_jumpdistance}");
 
-            Config.UserConfig.selected_mapJumpDistance = map_jumpdistance;
-            Config.UserConfig.selected_mapLowest = min_map_jumpdistance;
-            Config.Write();
+
+        // For when user selects a map with only 1 difficulty or selects a map but does not click a difficulty
+        private void Leveldetail_didChangeContentEvent(StandardLevelDetailViewController arg1, StandardLevelDetailViewController.ContentType arg2)
+        {
+            if (arg1 != null && arg1.selectedDifficultyBeatmap != null)
+            {
+                BeatmapInfo.SetSelected(arg1.selectedDifficultyBeatmap);
+            }
         }
 
 

--- a/UI/BSML/modifierOnlineUI.bsml
+++ b/UI/BSML/modifierOnlineUI.bsml
@@ -1,31 +1,35 @@
 ﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
-	<settings-container child-control-width='true' child-expand-width='true' size-delta-y='-15'>
-		<checkbox-setting value ='enabled' on-change='setEnabled' text='Enabled'></checkbox-setting>
-		<horizontal>
-			<grid cell-size-y='9' cell-size-x='28' spacing-x='2' align='Right'>
-				<text text='Map Jump Distance' align='Left'/>
-				<text text='-----------------' align='Left' rich-text='true' font-color='#00000000'/>
-				<button id='jdbutton' text='~button-text' on-click='refresh' min-width='29' align='Right' hover-hint='Refresh to show original JD for current map. Applicable in Multiplayer only when you are selecting the map.'/>
-			</grid>
-		</horizontal>
-		<slider-setting id='jumpDisSlider' value ='jumpDisValue' on-change='setJumpDis' text='Desired Jump Distance' increment='0.1' min='~minJump' max='~maxJump' hover-hint='Will attempt run map at this JD or as close as possible'></slider-setting>
-		<checkbox-setting value='usePrefJumpValues' on-change='setUsePrefJumpValues' text='Use Preferred JD values'></checkbox-setting>
-		<checkbox-setting value='useHeuristic' on-change='setUseHeuristic' text='Use Map JD If Lower' hover-hint='If original JD is lower than the matching preference, map will run at original JD'></checkbox-setting>
-		<button align='Center' on-click='prefButtonClicked' text='Jump Distance Preferences' hover-hint='Selects matching or lower NJS'></button>
+  <settings-container child-control-width='true' child-expand-width='true' size-delta-y='-15'>
+    <checkbox-setting value ='enabled' on-change='setEnabled' text='Enabled'></checkbox-setting>
+    <horizontal>
+      <grid cell-size-y='5' cell-size-x='28' spacing-x='2' align='Right'>
+        <text text='Map Jump Distance' align='Left'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~mapDefaultJD' align='Left'/>
 
-		<horizontal>
-			<grid cell-size-y='9' cell-size-x='28' spacing-x='2' align='Right'>
-				<text text='Upper Threshold' align='Left'/>
-				<text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
-				<text text='~upperthreshold' min-width='29' align='Center' hover-hint='Maps at and above this NJS will run at original JD'/>
+        <text text='Min. JD' align='Left'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~mapMinJD' align='Left'/>
+      </grid>
+    </horizontal>
+    <slider-setting id='jumpDisSlider' value ='jumpDisValue' on-change='setJumpDis' text='Desired Jump Distance' increment='0.1' min='~minJump' max='~maxJump' hover-hint='Will attempt run map at this JD or as close as possible'></slider-setting>
+    <checkbox-setting value='usePrefJumpValues' on-change='setUsePrefJumpValues' text='Use Preferred JD values'></checkbox-setting>
+    <checkbox-setting value='useHeuristic' on-change='setUseHeuristic' text='Use Map JD If Lower' hover-hint='If original JD is lower than the matching preference, map will run at original JD'></checkbox-setting>
+    <button align='Center' on-click='prefButtonClicked' text='Jump Distance Preferences' hover-hint='Selects matching or lower NJS'></button>
 
-				<text text='Lower Threshold' align='Left'/>
-				<text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
-				<text text='~lowerthreshold' min-width='29' align='Center' hover-hint='Maps at and below this NJS will run at original JD'/>
-			</grid>
-		</horizontal>
-	
-	</settings-container>
-	<button id='leftButton' text='&lt;' direction='Left' />
-	<button id='rightButton' text='&gt;' direction='Right' />
+    <horizontal>
+      <grid cell-size-y='9' cell-size-x='28' spacing-x='2' align='Right'>
+        <text text='Upper Threshold' align='Left'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~upperthreshold' min-width='29' align='Center' hover-hint='Maps at and above this NJS will run at original JD'/>
+
+        <text text='Lower Threshold' align='Left'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~lowerthreshold' min-width='29' align='Center' hover-hint='Maps at and below this NJS will run at original JD'/>
+      </grid>
+    </horizontal>
+
+  </settings-container>
+  <button id='leftButton' text='&lt;' direction='Left' />
+  <button id='rightButton' text='&gt;' direction='Right' />
 </bg>

--- a/UI/BSML/modifierUI.bsml
+++ b/UI/BSML/modifierUI.bsml
@@ -1,33 +1,37 @@
 ﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
-	<settings-container child-control-width='true' child-expand-width='true' size-delta-y='-15'>
-		<checkbox-setting value ='enabled' on-change='setEnabled' text='Enabled'></checkbox-setting>
-		<checkbox-setting value ='practiceEnabled' on-change='setPracticeEnabled' text='Practice Mode'></checkbox-setting>
+  <settings-container child-control-width='true' child-expand-width='true' size-delta-y='-15'>
+    <checkbox-setting value ='enabled' on-change='setEnabled' text='Enabled'></checkbox-setting>
+    <checkbox-setting value ='practiceEnabled' on-change='setPracticeEnabled' text='Practice Mode'></checkbox-setting>
 
-		<horizontal>
-			<grid cell-size-y='9' cell-size-x='28' spacing-x='2' align='Right'>
-			<text text='~mapJDText' align='Left'/>
-			<text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
-			<button text='~mapJDButton' on-click='mapJD-refresh' min-width='29' align='Right' hover-hint='Refresh to show original and minimum JD for current map. Applies in Multiplayer only when you are selecting the map'/>
-			</grid>
-		</horizontal>
+    <horizontal>
+      <grid cell-size-y='5' cell-size-x='28' spacing-x='2' align='Right'>
+        <text text='Map Jump Distance' align='Left'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~mapDefaultJD' align='Left'/>
 
-		<slider-setting id='jumpDisSlider' value ='jumpDisValue' on-change='setJumpDis' text='Desired Jump Distance' increment='0.1' min='~minJump' max='~maxJump' hover-hint='Run map at this JD or as close to it as possible'></slider-setting>
-		<checkbox-setting value='usePrefJumpValues' on-change='setUsePrefJumpValues' text='Use JD Preferences'></checkbox-setting>
-		<checkbox-setting value='useHeuristic' on-change='setUseHeuristic' text='Use Map JD If Lower' hover-hint='If original JD is lower than the matching preference, map will run at original JD'></checkbox-setting>
-		<button align='Center' on-click='prefButtonClicked' text='Jump Distance Preferences' hover-hint='Select by matching or lower NJS'></button>
+        <text text='Min. JD' align='Left'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~mapMinJD' align='Left'/>
+      </grid>
+    </horizontal>
 
-		<horizontal>
-			<grid cell-size-y='9' cell-size-x='28' spacing-x='2' align='Right'>
-				<text text='Upper Threshold' align='Left' hover-hint='Set in config'/>
-				<text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
-				<text text='~upperthreshold' min-width='29' align='Center' hover-hint='Maps at and above this NJS will run at original JD'/>
-				
-				<text text='Lower Threshold' align='Left' hover-hint='Set in config'/>
-				<text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
-				<text text='~lowerthreshold' min-width='29' align='Center' hover-hint='Maps at and below this NJS will run at original JD.'/>
-			</grid>
-		</horizontal>
-	</settings-container>
-	<button id='leftButton' text='&lt;' direction='Left' />
-	<button id='rightButton' text='&gt;' direction='Right' />
+    <slider-setting id='jumpDisSlider' value ='jumpDisValue' on-change='setJumpDis' text='Desired Jump Distance' increment='0.1' min='~minJump' max='~maxJump' hover-hint='Run map at this JD or as close to it as possible'></slider-setting>
+    <checkbox-setting value='usePrefJumpValues' on-change='setUsePrefJumpValues' text='Use JD Preferences'></checkbox-setting>
+    <checkbox-setting value='useHeuristic' on-change='setUseHeuristic' text='Use Map JD If Lower' hover-hint='If original JD is lower than the matching preference, map will run at original JD'></checkbox-setting>
+    <button align='Center' on-click='prefButtonClicked' text='Jump Distance Preferences' hover-hint='Select by matching or lower NJS'></button>
+
+    <horizontal>
+      <grid cell-size-y='9' cell-size-x='28' spacing-x='2' align='Right'>
+        <text text='Upper Threshold' align='Left' hover-hint='Set in config'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~upperthreshold' min-width='29' align='Center' hover-hint='Maps at and above this NJS will run at original JD'/>
+
+        <text text='Lower Threshold' align='Left' hover-hint='Set in config'/>
+        <text text='----------------' align='Left' rich-text='true' font-color='#00000000'/>
+        <text text='~lowerthreshold' min-width='29' align='Center' hover-hint='Maps at and below this NJS will run at original JD.'/>
+      </grid>
+    </horizontal>
+  </settings-container>
+  <button id='leftButton' text='&lt;' direction='Left' />
+  <button id='rightButton' text='&gt;' direction='Right' />
 </bg>

--- a/UI/ModifierUI.cs
+++ b/UI/ModifierUI.cs
@@ -9,6 +9,17 @@ namespace JDFixer.UI
 {
     public class ModifierUI : NotifiableSingleton<ModifierUI>
     {
+        private BeatmapInfo _selectedBeatmap = BeatmapInfo.Empty; 
+        public ModifierUI()
+        {
+            BeatmapInfo.SelectedChanged += beatmapInfo =>
+            {
+                _selectedBeatmap = beatmapInfo;
+                NotifyPropertyChanged(nameof(MapDefaultJDText));
+                NotifyPropertyChanged(nameof(MapMinJDText));
+            };
+        }
+
         private PreferencesFlowCoordinator _prefFlow;
         [UIValue("minJump")]
         private int minJump => Config.UserConfig.minJumpDistance;
@@ -71,30 +82,23 @@ namespace JDFixer.UI
         }
         */
 
-        [UIValue("mapJDText")]
-        private string MapJDText
-        {
-            get => "Map Jump Distance\nMin. JD";
-        }
 
         //[UIComponent("mapJDButton")]
         //private string MapJDButton;
-        [UIValue("mapJDButton")]
-        public string MapJDButton
-        {
-            get => "<#ffff00>" + Config.UserConfig.selected_mapJumpDistance.ToString() + "\n" + "<#c4c4c4>" + Config.UserConfig.selected_mapLowest.ToString();
-            set
-            {
-                NotifyPropertyChanged();
-            }
-        }
+        //[UIValue("mapJDLabel")]
+        //public string MapJDLabel => "Map Jump Distance\nMin. JD";
 
-        [UIAction("mapJD-refresh")]
-        void MapJDRefresh()
-        {
-            MapJDButton = "something changed"; // This is a hack. Without an assignment button doesn't update when clicked lol
-            //Logger.log.Debug($"After click {MapJDButton}");
-        }
+        //[UIValue("mapJDText")]
+        //public string MapJDText => $"<#ffff00>" + _selectedBeatmap.JumpDistance.ToString() + "\n" + "<#c4c4c4>" + _selectedBeatmap.MinJumpDistance.ToString();
+
+
+        [UIValue("mapDefaultJD")]
+        public string MapDefaultJDText => "<#ffff00>" + _selectedBeatmap.JumpDistance.ToString();
+
+
+        [UIValue("mapMinJD")]
+        public string MapMinJDText => "<#c4c4c4>" + _selectedBeatmap.MinJumpDistance.ToString();
+
         //#####################################################
 
 
@@ -193,32 +197,6 @@ namespace JDFixer.UI
                 return flow;
             }
             return DeepestChildFlowCoordinator(flow);
-        }
-
-        // For when user selects a map with only 1 difficulty or selects a map but does not click a difficulty
-        public static void Leveldetail_didChangeContentEvent(StandardLevelDetailViewController arg1, StandardLevelDetailViewController.ContentType arg2)
-        {
-            if (arg1 != null && arg1.selectedDifficultyBeatmap != null)
-            {               
-                float map_bpm = arg1.selectedDifficultyBeatmap.level.beatsPerMinute;
-                float map_njs = arg1.selectedDifficultyBeatmap.noteJumpMovementSpeed;
-                //float map_halfjump = 4f;
-                float map_offset = arg1.selectedDifficultyBeatmap.noteJumpStartBeatOffset;
-
-                // NOTE THESE DONT WORK: SONG LOADS FOREVER
-                //float bpm = arg1.beatmapLevel.beatsPerMinute;
-                //float offset = arg1.beatmapLevel.songTimeOffset;
-                //String songname = arg1.beatmapLevel.songName;
-
-                float map_jumpdistance = JDFixer.Plugin.Calculate_JD(map_bpm, map_njs, map_offset);
-                float min_map_jumpdistance = JDFixer.Plugin.Calculate_JD(map_bpm, map_njs, -50f);
-
-                Logger.log.Debug($"UI: BPM: {map_bpm} | NJS: {map_njs} | Offset: {map_offset} | Jump Distance: { map_jumpdistance} | Minimum: { min_map_jumpdistance}");
-
-                Config.UserConfig.selected_mapJumpDistance = map_jumpdistance;
-                Config.UserConfig.selected_mapLowest = min_map_jumpdistance;
-                Config.Write();
-            }
         }
     }
 }

--- a/UI/ModifierUI.cs
+++ b/UI/ModifierUI.cs
@@ -58,48 +58,12 @@ namespace JDFixer.UI
         }
 
 
-        //#####################################################
-        // Jump Distance Refresh Button
-        // Yes, i tried everything make an autoupdating text tag lol
-        /*
-        [UIComponent("jdbutton")]
-        private string jdbutton;
-        [UIValue("button-text")]
-        public string ButtonText
-        {
-            get => "<#ebbd52>" + Config.UserConfig.selected_mapJumpDistance.ToString();
-            set
-            {
-                NotifyPropertyChanged();
-            }
-        }
-
-        [UIAction("refresh")]
-        void Refresh()
-        {
-            ButtonText = "something changed"; // This is a hack. Without this the button text doesn't update when clicked lol
-            //Logger.log.Debug($"After click {ButtonText}");
-        }
-        */
-
-
-        //[UIComponent("mapJDButton")]
-        //private string MapJDButton;
-        //[UIValue("mapJDLabel")]
-        //public string MapJDLabel => "Map Jump Distance\nMin. JD";
-
-        //[UIValue("mapJDText")]
-        //public string MapJDText => $"<#ffff00>" + _selectedBeatmap.JumpDistance.ToString() + "\n" + "<#c4c4c4>" + _selectedBeatmap.MinJumpDistance.ToString();
-
-
         [UIValue("mapDefaultJD")]
         public string MapDefaultJDText => "<#ffff00>" + _selectedBeatmap.JumpDistance.ToString();
 
 
         [UIValue("mapMinJD")]
         public string MapMinJDText => "<#c4c4c4>" + _selectedBeatmap.MinJumpDistance.ToString();
-
-        //#####################################################
 
 
         [UIComponent("jumpDisSlider")]


### PR DESCRIPTION
Changes to make the JD refresh without needing to click a button.

Some internal changes:
* Moved current map default/min jump distance outside config class as this caused it to be saved in the config json (and made it harder to fix the auto-refresh).
* Moved Leveldetail_didChangeContentEvent to Plugin.cs as it wasn't referencing anything from ModifierUI.
* Changed the JD refresh button to text.